### PR TITLE
Surge improvements

### DIFF
--- a/My Project/Settings.Designer.vb
+++ b/My Project/Settings.Designer.vb
@@ -230,6 +230,18 @@ Namespace My
                 Me("bSurgePlusPrompt") = value
             End Set
         End Property
+
+        <Global.System.Configuration.UserScopedSettingAttribute(), _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(), _
+         Global.System.Configuration.DefaultSettingValueAttribute("False")> _
+        Public Property bAutoSurge() As Boolean
+            Get
+                Return CType(Me("bAutoSurge"), Boolean)
+            End Get
+            Set(value As Boolean)
+                Me("bAutoSurge") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/My Project/Settings.Designer.vb
+++ b/My Project/Settings.Designer.vb
@@ -218,6 +218,18 @@ Namespace My
                 Me("bWhiteMonsterBGs") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+        Public Property bSurgePlusPrompt() As Boolean
+            Get
+                Return CType(Me("bSurgePlusPrompt"),Boolean)
+            End Get
+            Set
+                Me("bSurgePlusPrompt") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/My Project/Settings.settings
+++ b/My Project/Settings.settings
@@ -47,5 +47,8 @@
     <Setting Name="bSurgePlusPrompt" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="bAutoSurge" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/My Project/Settings.settings
+++ b/My Project/Settings.settings
@@ -44,5 +44,8 @@
     <Setting Name="bWhiteMonsterBGs" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="bSurgePlusPrompt" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/_Config/Config.Designer.vb
+++ b/_Config/Config.Designer.vb
@@ -24,6 +24,8 @@ Partial Class Config
     Private Sub InitializeComponent()
         Me.TabControl1 = New System.Windows.Forms.TabControl()
         Me.tabGeneral = New System.Windows.Forms.TabPage()
+        Me.cfgAutoSurge = New System.Windows.Forms.CheckBox()
+        Me.cfgSurgePlusPrompt = New System.Windows.Forms.CheckBox()
         Me.cfgWhiteMonsterBGs = New System.Windows.Forms.CheckBox()
         Me.cfgRollEffectSaves = New System.Windows.Forms.CheckBox()
         Me.cfgRollPowerRecharge = New System.Windows.Forms.CheckBox()
@@ -41,7 +43,6 @@ Partial Class Config
         Me.Label1 = New System.Windows.Forms.Label()
         Me.btnOk = New System.Windows.Forms.Button()
         Me.btnCancel = New System.Windows.Forms.Button()
-        Me.cfgSurgePlusPrompt = New System.Windows.Forms.CheckBox()
         Me.TabControl1.SuspendLayout()
         Me.tabGeneral.SuspendLayout()
         Me.tabSecondaryDisplay.SuspendLayout()
@@ -56,11 +57,12 @@ Partial Class Config
         Me.TabControl1.Multiline = True
         Me.TabControl1.Name = "TabControl1"
         Me.TabControl1.SelectedIndex = 0
-        Me.TabControl1.Size = New System.Drawing.Size(385, 220)
+        Me.TabControl1.Size = New System.Drawing.Size(385, 251)
         Me.TabControl1.TabIndex = 0
         '
         'tabGeneral
         '
+        Me.tabGeneral.Controls.Add(Me.cfgAutoSurge)
         Me.tabGeneral.Controls.Add(Me.cfgSurgePlusPrompt)
         Me.tabGeneral.Controls.Add(Me.cfgWhiteMonsterBGs)
         Me.tabGeneral.Controls.Add(Me.cfgRollEffectSaves)
@@ -72,10 +74,30 @@ Partial Class Config
         Me.tabGeneral.Location = New System.Drawing.Point(4, 22)
         Me.tabGeneral.Name = "tabGeneral"
         Me.tabGeneral.Padding = New System.Windows.Forms.Padding(3)
-        Me.tabGeneral.Size = New System.Drawing.Size(377, 194)
+        Me.tabGeneral.Size = New System.Drawing.Size(377, 225)
         Me.tabGeneral.TabIndex = 0
         Me.tabGeneral.Text = "General"
         Me.tabGeneral.UseVisualStyleBackColor = True
+        '
+        'cfgAutoSurge
+        '
+        Me.cfgAutoSurge.AutoSize = True
+        Me.cfgAutoSurge.Location = New System.Drawing.Point(6, 190)
+        Me.cfgAutoSurge.Name = "cfgAutoSurge"
+        Me.cfgAutoSurge.Size = New System.Drawing.Size(331, 17)
+        Me.cfgAutoSurge.TabIndex = 8
+        Me.cfgAutoSurge.Text = "Automatically apply healing and remove surge using surge button"
+        Me.cfgAutoSurge.UseVisualStyleBackColor = True
+        '
+        'cfgSurgePlusPrompt
+        '
+        Me.cfgSurgePlusPrompt.AutoSize = True
+        Me.cfgSurgePlusPrompt.Location = New System.Drawing.Point(6, 167)
+        Me.cfgSurgePlusPrompt.Name = "cfgSurgePlusPrompt"
+        Me.cfgSurgePlusPrompt.Size = New System.Drawing.Size(259, 17)
+        Me.cfgSurgePlusPrompt.TabIndex = 7
+        Me.cfgSurgePlusPrompt.Text = "Prompt for value to add when using healing surge"
+        Me.cfgSurgePlusPrompt.UseVisualStyleBackColor = True
         '
         'cfgWhiteMonsterBGs
         '
@@ -155,7 +177,7 @@ Partial Class Config
         Me.tabSecondaryDisplay.Location = New System.Drawing.Point(4, 22)
         Me.tabSecondaryDisplay.Name = "tabSecondaryDisplay"
         Me.tabSecondaryDisplay.Padding = New System.Windows.Forms.Padding(3)
-        Me.tabSecondaryDisplay.Size = New System.Drawing.Size(377, 165)
+        Me.tabSecondaryDisplay.Size = New System.Drawing.Size(377, 225)
         Me.tabSecondaryDisplay.TabIndex = 1
         Me.tabSecondaryDisplay.Text = "Secondary Display"
         Me.tabSecondaryDisplay.UseVisualStyleBackColor = True
@@ -231,7 +253,7 @@ Partial Class Config
         '
         'btnOk
         '
-        Me.btnOk.Location = New System.Drawing.Point(237, 234)
+        Me.btnOk.Location = New System.Drawing.Point(237, 269)
         Me.btnOk.Name = "btnOk"
         Me.btnOk.Size = New System.Drawing.Size(75, 23)
         Me.btnOk.TabIndex = 1
@@ -240,22 +262,12 @@ Partial Class Config
         '
         'btnCancel
         '
-        Me.btnCancel.Location = New System.Drawing.Point(318, 234)
+        Me.btnCancel.Location = New System.Drawing.Point(318, 269)
         Me.btnCancel.Name = "btnCancel"
         Me.btnCancel.Size = New System.Drawing.Size(75, 23)
         Me.btnCancel.TabIndex = 2
         Me.btnCancel.Text = "Cancel"
         Me.btnCancel.UseVisualStyleBackColor = True
-        '
-        'cfgSurgePlusPrompt
-        '
-        Me.cfgSurgePlusPrompt.AutoSize = True
-        Me.cfgSurgePlusPrompt.Location = New System.Drawing.Point(6, 167)
-        Me.cfgSurgePlusPrompt.Name = "cfgSurgePlusPrompt"
-        Me.cfgSurgePlusPrompt.Size = New System.Drawing.Size(259, 17)
-        Me.cfgSurgePlusPrompt.TabIndex = 7
-        Me.cfgSurgePlusPrompt.Text = "Prompt for value to add when using healing surge"
-        Me.cfgSurgePlusPrompt.UseVisualStyleBackColor = True
         '
         'Config
         '
@@ -298,4 +310,5 @@ Partial Class Config
     Friend WithEvents Label1 As System.Windows.Forms.Label
     Friend WithEvents cfgWhiteMonsterBGs As System.Windows.Forms.CheckBox
     Friend WithEvents cfgSurgePlusPrompt As System.Windows.Forms.CheckBox
+    Friend WithEvents cfgAutoSurge As System.Windows.Forms.CheckBox
 End Class

--- a/_Config/Config.Designer.vb
+++ b/_Config/Config.Designer.vb
@@ -22,25 +22,26 @@ Partial Class Config
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
-        Me.TabControl1 = New System.Windows.Forms.TabControl
-        Me.tabGeneral = New System.Windows.Forms.TabPage
-        Me.cfgRollEffectSaves = New System.Windows.Forms.CheckBox
-        Me.cfgRollPowerRecharge = New System.Windows.Forms.CheckBox
-        Me.cfgSurpriseRound = New System.Windows.Forms.CheckBox
-        Me.cfgOngoingPopup = New System.Windows.Forms.CheckBox
-        Me.cfgGroupSimilar = New System.Windows.Forms.CheckBox
-        Me.cfgAutoCompendium = New System.Windows.Forms.CheckBox
-        Me.tabSecondaryDisplay = New System.Windows.Forms.TabPage
-        Me.GroupBox1 = New System.Windows.Forms.GroupBox
-        Me.cfgDisplayOtherHP = New System.Windows.Forms.CheckBox
-        Me.cfgDisplayHeroHP = New System.Windows.Forms.CheckBox
-        Me.cfgDisplayInit = New System.Windows.Forms.CheckBox
-        Me.cfgDisplayRound = New System.Windows.Forms.CheckBox
-        Me.cfgHttpPort = New System.Windows.Forms.TextBox
-        Me.Label1 = New System.Windows.Forms.Label
-        Me.btnOk = New System.Windows.Forms.Button
-        Me.btnCancel = New System.Windows.Forms.Button
-        Me.cfgWhiteMonsterBGs = New System.Windows.Forms.CheckBox
+        Me.TabControl1 = New System.Windows.Forms.TabControl()
+        Me.tabGeneral = New System.Windows.Forms.TabPage()
+        Me.cfgWhiteMonsterBGs = New System.Windows.Forms.CheckBox()
+        Me.cfgRollEffectSaves = New System.Windows.Forms.CheckBox()
+        Me.cfgRollPowerRecharge = New System.Windows.Forms.CheckBox()
+        Me.cfgSurpriseRound = New System.Windows.Forms.CheckBox()
+        Me.cfgOngoingPopup = New System.Windows.Forms.CheckBox()
+        Me.cfgGroupSimilar = New System.Windows.Forms.CheckBox()
+        Me.cfgAutoCompendium = New System.Windows.Forms.CheckBox()
+        Me.tabSecondaryDisplay = New System.Windows.Forms.TabPage()
+        Me.GroupBox1 = New System.Windows.Forms.GroupBox()
+        Me.cfgDisplayOtherHP = New System.Windows.Forms.CheckBox()
+        Me.cfgDisplayHeroHP = New System.Windows.Forms.CheckBox()
+        Me.cfgDisplayInit = New System.Windows.Forms.CheckBox()
+        Me.cfgDisplayRound = New System.Windows.Forms.CheckBox()
+        Me.cfgHttpPort = New System.Windows.Forms.TextBox()
+        Me.Label1 = New System.Windows.Forms.Label()
+        Me.btnOk = New System.Windows.Forms.Button()
+        Me.btnCancel = New System.Windows.Forms.Button()
+        Me.cfgSurgePlusPrompt = New System.Windows.Forms.CheckBox()
         Me.TabControl1.SuspendLayout()
         Me.tabGeneral.SuspendLayout()
         Me.tabSecondaryDisplay.SuspendLayout()
@@ -55,11 +56,12 @@ Partial Class Config
         Me.TabControl1.Multiline = True
         Me.TabControl1.Name = "TabControl1"
         Me.TabControl1.SelectedIndex = 0
-        Me.TabControl1.Size = New System.Drawing.Size(385, 191)
+        Me.TabControl1.Size = New System.Drawing.Size(385, 220)
         Me.TabControl1.TabIndex = 0
         '
         'tabGeneral
         '
+        Me.tabGeneral.Controls.Add(Me.cfgSurgePlusPrompt)
         Me.tabGeneral.Controls.Add(Me.cfgWhiteMonsterBGs)
         Me.tabGeneral.Controls.Add(Me.cfgRollEffectSaves)
         Me.tabGeneral.Controls.Add(Me.cfgRollPowerRecharge)
@@ -70,10 +72,20 @@ Partial Class Config
         Me.tabGeneral.Location = New System.Drawing.Point(4, 22)
         Me.tabGeneral.Name = "tabGeneral"
         Me.tabGeneral.Padding = New System.Windows.Forms.Padding(3)
-        Me.tabGeneral.Size = New System.Drawing.Size(377, 165)
+        Me.tabGeneral.Size = New System.Drawing.Size(377, 194)
         Me.tabGeneral.TabIndex = 0
         Me.tabGeneral.Text = "General"
         Me.tabGeneral.UseVisualStyleBackColor = True
+        '
+        'cfgWhiteMonsterBGs
+        '
+        Me.cfgWhiteMonsterBGs.AutoSize = True
+        Me.cfgWhiteMonsterBGs.Location = New System.Drawing.Point(6, 144)
+        Me.cfgWhiteMonsterBGs.Name = "cfgWhiteMonsterBGs"
+        Me.cfgWhiteMonsterBGs.Size = New System.Drawing.Size(347, 17)
+        Me.cfgWhiteMonsterBGs.TabIndex = 6
+        Me.cfgWhiteMonsterBGs.Text = "Use White Backgrounds for NPCs and Monsters (Red when Bloody)"
+        Me.cfgWhiteMonsterBGs.UseVisualStyleBackColor = True
         '
         'cfgRollEffectSaves
         '
@@ -219,7 +231,7 @@ Partial Class Config
         '
         'btnOk
         '
-        Me.btnOk.Location = New System.Drawing.Point(237, 209)
+        Me.btnOk.Location = New System.Drawing.Point(237, 234)
         Me.btnOk.Name = "btnOk"
         Me.btnOk.Size = New System.Drawing.Size(75, 23)
         Me.btnOk.TabIndex = 1
@@ -228,28 +240,28 @@ Partial Class Config
         '
         'btnCancel
         '
-        Me.btnCancel.Location = New System.Drawing.Point(318, 209)
+        Me.btnCancel.Location = New System.Drawing.Point(318, 234)
         Me.btnCancel.Name = "btnCancel"
         Me.btnCancel.Size = New System.Drawing.Size(75, 23)
         Me.btnCancel.TabIndex = 2
         Me.btnCancel.Text = "Cancel"
         Me.btnCancel.UseVisualStyleBackColor = True
         '
-        'cfgWhiteMonsterBGs
+        'cfgSurgePlusPrompt
         '
-        Me.cfgWhiteMonsterBGs.AutoSize = True
-        Me.cfgWhiteMonsterBGs.Location = New System.Drawing.Point(6, 144)
-        Me.cfgWhiteMonsterBGs.Name = "cfgWhiteMonsterBGs"
-        Me.cfgWhiteMonsterBGs.Size = New System.Drawing.Size(347, 17)
-        Me.cfgWhiteMonsterBGs.TabIndex = 6
-        Me.cfgWhiteMonsterBGs.Text = "Use White Backgrounds for NPCs and Monsters (Red when Bloody)"
-        Me.cfgWhiteMonsterBGs.UseVisualStyleBackColor = True
+        Me.cfgSurgePlusPrompt.AutoSize = True
+        Me.cfgSurgePlusPrompt.Location = New System.Drawing.Point(6, 167)
+        Me.cfgSurgePlusPrompt.Name = "cfgSurgePlusPrompt"
+        Me.cfgSurgePlusPrompt.Size = New System.Drawing.Size(259, 17)
+        Me.cfgSurgePlusPrompt.TabIndex = 7
+        Me.cfgSurgePlusPrompt.Text = "Prompt for value to add when using healing surge"
+        Me.cfgSurgePlusPrompt.UseVisualStyleBackColor = True
         '
         'Config
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(409, 244)
+        Me.ClientSize = New System.Drawing.Size(409, 323)
         Me.Controls.Add(Me.btnCancel)
         Me.Controls.Add(Me.btnOk)
         Me.Controls.Add(Me.TabControl1)
@@ -285,4 +297,5 @@ Partial Class Config
     Friend WithEvents cfgHttpPort As System.Windows.Forms.TextBox
     Friend WithEvents Label1 As System.Windows.Forms.Label
     Friend WithEvents cfgWhiteMonsterBGs As System.Windows.Forms.CheckBox
+    Friend WithEvents cfgSurgePlusPrompt As System.Windows.Forms.CheckBox
 End Class

--- a/_Config/Config.vb
+++ b/_Config/Config.vb
@@ -16,6 +16,7 @@
         cfgHttpPort.Text = My.Settings.htmlPort.ToString
         cfgWhiteMonsterBGs.Checked = My.Settings.bWhiteMonsterBGs
         cfgSurgePlusPrompt.Checked = My.Settings.bSurgePlusPrompt
+        cfgAutoSurge.Checked = My.Settings.bAutoSurge
         changed = False
     End Sub
     Private Sub ValuesChanged(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles cfgAutoCompendium.CheckedChanged, cfgDisplayHeroHP.CheckedChanged, cfgDisplayInit.CheckedChanged, cfgDisplayOtherHP.CheckedChanged, cfgDisplayRound.CheckedChanged, cfgGroupSimilar.CheckedChanged, cfgOngoingPopup.CheckedChanged, cfgRollEffectSaves.CheckedChanged, cfgRollPowerRecharge.CheckedChanged, cfgSurpriseRound.CheckedChanged, cfgWhiteMonsterBGs.CheckedChanged
@@ -56,6 +57,7 @@
         My.Settings.bSurpriseRound = cfgSurpriseRound.Checked
         My.Settings.bWhiteMonsterBGs = cfgWhiteMonsterBGs.Checked
         My.Settings.bSurgePlusPrompt = cfgSurgePlusPrompt.Checked
+        My.Settings.bAutoSurge = cfgAutoSurge.Checked
         changed = False
     End Sub
 
@@ -68,4 +70,5 @@
         changed = False
         Me.Close()
     End Sub
+
 End Class

--- a/_Config/Config.vb
+++ b/_Config/Config.vb
@@ -15,6 +15,7 @@
         cfgSurpriseRound.Checked = My.Settings.bSurpriseRound
         cfgHttpPort.Text = My.Settings.htmlPort.ToString
         cfgWhiteMonsterBGs.Checked = My.Settings.bWhiteMonsterBGs
+        cfgSurgePlusPrompt.Checked = My.Settings.bSurgePlusPrompt
         changed = False
     End Sub
     Private Sub ValuesChanged(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles cfgAutoCompendium.CheckedChanged, cfgDisplayHeroHP.CheckedChanged, cfgDisplayInit.CheckedChanged, cfgDisplayOtherHP.CheckedChanged, cfgDisplayRound.CheckedChanged, cfgGroupSimilar.CheckedChanged, cfgOngoingPopup.CheckedChanged, cfgRollEffectSaves.CheckedChanged, cfgRollPowerRecharge.CheckedChanged, cfgSurpriseRound.CheckedChanged, cfgWhiteMonsterBGs.CheckedChanged
@@ -54,6 +55,7 @@
         My.Settings.bRollPowerRecharge = cfgRollPowerRecharge.Checked
         My.Settings.bSurpriseRound = cfgSurpriseRound.Checked
         My.Settings.bWhiteMonsterBGs = cfgWhiteMonsterBGs.Checked
+        My.Settings.bSurgePlusPrompt = cfgSurgePlusPrompt.Checked
         changed = False
     End Sub
 

--- a/_Encounter/Dnd4eInitTracker.vb
+++ b/_Encounter/Dnd4eInitTracker.vb
@@ -312,8 +312,15 @@ Public Class frmTracker
         Dim fighter As Combatant = ListSelectedFighter
 
         If Not fighter Is Nothing Then
-            dfDamHealAmt.Value = fighter.nSurgeValue
-            dfDamHealAmt.Focus()
+            If My.Settings.bSurgePlusPrompt Then
+                Dim nAdditionalHealing As Integer
+                nAdditionalHealing = Val(InputBox("Base healing surge is " & fighter.nSurgeValue & ". Additional healing:", "Healing Surge"))
+                dfDamHealAmt.Value = fighter.nSurgeValue + nAdditionalHealing
+                dfDamHealAmt.Focus()
+            Else
+                dfDamHealAmt.Value = fighter.nSurgeValue
+                dfDamHealAmt.Focus()
+            End If
         End If
     End Sub
     Private Sub pbMaxHP_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles pbMaxHP.Click

--- a/_Encounter/Dnd4eInitTracker.vb
+++ b/_Encounter/Dnd4eInitTracker.vb
@@ -314,12 +314,37 @@ Public Class frmTracker
         If Not fighter Is Nothing Then
             If My.Settings.bSurgePlusPrompt Then
                 Dim nAdditionalHealing As Integer
-                nAdditionalHealing = Val(InputBox("Base healing surge is " & fighter.nSurgeValue & ". Additional healing:", "Healing Surge"))
+
+                nAdditionalHealing = Val(InputBox("Base healing surge is " & fighter.nSurgeValue & Environment.NewLine _
+                                                  & fighter.sName & " has " & fighter.nSurgesLeft & " healing surges left." & Environment.NewLine & Environment.NewLine _
+                                                  & "Additional healing:", "Healing Surge", "0"))
                 dfDamHealAmt.Value = fighter.nSurgeValue + nAdditionalHealing
-                dfDamHealAmt.Focus()
             Else
                 dfDamHealAmt.Value = fighter.nSurgeValue
-                dfDamHealAmt.Focus()
+            End If
+            dfDamHealAmt.Focus()
+
+            If My.Settings.bAutoSurge Then
+                ' Make sure they have surges remaining
+                If (fighter.nSurgesLeft <= 0) Then
+                    Dim reply As DialogResult = MessageBox.Show(fighter.sName & " is out of healing surges.  Proceed anyways?", "Out of healing surges", _
+                                                                MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation, MessageBoxDefaultButton.Button1)
+                    If reply = Windows.Forms.DialogResult.No Then
+                        Return
+                    End If
+                End If
+                Dim usesurge As DialogResult = MessageBox.Show("Heal " & fighter.sName & " for " & dfDamHealAmt.Value & "?", "Healing surge", _
+                                                               MessageBoxButtons.YesNo, MessageBoxIcon.Question, MessageBoxDefaultButton.Button1)
+                If usesurge = Windows.Forms.DialogResult.No Then
+                    Return
+                End If
+
+                ' Heal them
+                fighter.Heal(dfDamHealAmt.Value)
+                UpdateFromClass()
+                ' Use a surge
+                fighter.ModSurges(-1)
+                dfSurgesLeft.Text = fighter.sSurgeView
             End If
         End If
     End Sub

--- a/app.config
+++ b/app.config
@@ -78,9 +78,12 @@
             <setting name="bWhiteMonsterBGs" serializeAs="String">
                 <value>False</value>
             </setting>
-          <setting name="bSurgePlusPrompt" serializeAs="String">
-            <value>False</value>
-          </setting>
+            <setting name="bSurgePlusPrompt" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="bAutoSurge" serializeAs="String">
+                <value>False</value>
+            </setting>
         </DnD4e_Combat_Manager.My.MySettings>
     </userSettings>
 </configuration>

--- a/app.config
+++ b/app.config
@@ -78,6 +78,9 @@
             <setting name="bWhiteMonsterBGs" serializeAs="String">
                 <value>False</value>
             </setting>
+          <setting name="bSurgePlusPrompt" serializeAs="String">
+            <value>False</value>
+          </setting>
         </DnD4e_Combat_Manager.My.MySettings>
     </userSettings>
 </configuration>

--- a/bin/Release/DnD4e Combat Manager.exe.config
+++ b/bin/Release/DnD4e Combat Manager.exe.config
@@ -78,6 +78,9 @@
             <setting name="bWhiteMonsterBGs" serializeAs="String">
                 <value>False</value>
             </setting>
+          <setting name="bSurgePlusPrompt" serializeAs="String">
+            <value>False</value>
+          </setting>
         </DnD4e_Combat_Manager.My.MySettings>
     </userSettings>
 </configuration>

--- a/bin/Release/DnD4e Combat Manager.vshost.exe.config
+++ b/bin/Release/DnD4e Combat Manager.vshost.exe.config
@@ -78,6 +78,9 @@
             <setting name="bWhiteMonsterBGs" serializeAs="String">
                 <value>False</value>
             </setting>
+          <setting name="bSurgePlusPrompt" serializeAs="String">
+            <value>False</value>
+          </setting>
         </DnD4e_Combat_Manager.My.MySettings>
     </userSettings>
 </configuration>


### PR DESCRIPTION
This adds two new settings (both disabled by default) which affect the Surge button.

The first setting SurgePlusPrompt prompts for additional healing and adds it to their base surge.  This is extremely useful if you have a healer who almost always adds something to the player's surge value.

The second is AutoSurge, which pops up a Yes/No messagebox with how much they will be healed, and warns you if they are out of surges (but gives you the option to continue anyways).  If you click yes, it heals them and marks a surge as used.  This works well for me, because I am constantly forgetting to keep track of surge usages.
